### PR TITLE
added reading of pem files

### DIFF
--- a/bin/stateless-dane.js
+++ b/bin/stateless-dane.js
@@ -89,6 +89,7 @@ Examples:
   const command = config.str(0);
 
   const sign = config.bool('sign', true);
+  const port = config.uint('port', 443);
   const publicKeyFile = config.str('public-key-file');
   var publicKeyData
   if (publicKeyFile) {
@@ -99,6 +100,7 @@ Examples:
   const options = {
     resolverIP: config.str('resolver-ip') || undefined,
     resolverPort: config.str('resolver-port') || undefined,
+    port: config.uint('port') || undefined,
   }
 
   switch (command) {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "bns": "^0.15.0",
     "bsert": "^0.0.10",
     "hs-client": "^0.0.13",
+    "node-forge": "^1.3.1",
     "urkel": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Now when external public key is provided first it tries to read it as .pem and then tries previously the only json format of rsa key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced support for public key data formats, accommodating both PEM and JSON in `StatelessDANECertificate`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->